### PR TITLE
Remove "ge.tt" file hosting service - has been shutdown for some time

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ To save the world from creating user accounts and installing software applicatio
 ### File Hosting/Sharing
 
 * [EFShare](http://efshare.com/) - Peer to peer secure file sharing.
-* [Ge.tt](http://ge.tt/) - File hosting service. Max limit 2gb.
 * [RGhost](http://rgho.st/) - File hosting service, Max limit 100mb without login.
 * [ImgSafe](https://imgsafe.org/) - Image hosting service with small direct links.
 * [Clyp](https://clyp.it/) - Audio sharing without limits, rich API.


### PR DESCRIPTION
Hey there! 👋 

**Summary:** Removed "* [Ge.tt](http://ge.tt/) - File hosting service. Max limit 2gb."

Ge.tt got hacked at some point and is now defunct, some [info available here](https://wiki.archiveteam.org/index.php/Ge.tt). Linking to it now is potentially dangerous as someone may maliciously register the domain name.

# By submitting this pull request I confirm I've read and complied with the below requirements.

Failure to properly do so will just result in the pull request being closed and everyone's time wasted. Please read it twice. Most people miss many things.

- [x] I have read the [Contribution guidelines](https://github.com/aviaryan/awesome-no-login-web-apps/blob/master/CONTRIBUTING.md) and I am confident that my PR is suitable. 
- [x] This pull request has a descriptive title. For example, `Add [App name]`, not `Update readme.md` or `Added new entries`.
- [x] The app I added is not a duplicate.
