### PR TITLE
Add Shopify Theme Detector to Programming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Regulex](https://jex.im/regulex/) - JavaScript regular expression visualizer.
 * [GTmetrix](https://gtmetrix.com/) - Analyze your site’s speed and make it faster.
 * [BuildWith](https://builtwith.com/) - Find the technology stack to know everything about a website.
+* [Shopify Theme Detector](https://podifai.com/tools/shopify-theme-detector/) - Detect what Shopify theme any online store is using. Supports batch URLs. Completely free.
 * [WooRank](https://www.woorank.com/) - SEO Audit tool, provides website review with global and local rank in terms of traffic generated.
 * [CSS Typeset](http://csstypeset.com/) - Visual typeset editor. Play around with font-face, word-spacing and other text attributes and download the corresponding CSS.
 * [pForm](http://www.phpform.org/) - Create HTML forms through a simple WYSIWYG GUI and download the corresponding code.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Regulex](https://jex.im/regulex/) - JavaScript regular expression visualizer.
 * [GTmetrix](https://gtmetrix.com/) - Analyze your site’s speed and make it faster.
 * [BuildWith](https://builtwith.com/) - Find the technology stack to know everything about a website.
-* [Shopify Theme Detector](https://podifai.com/tools/shopify-theme-detector/) - Detect what Shopify theme any online store is using. Supports batch URLs. Completely free.
+* [Shopify Theme Detector](https://shopifythemedetector.com) - Detect what theme and apps any Shopify store uses. No login required.
 * [WooRank](https://www.woorank.com/) - SEO Audit tool, provides website review with global and local rank in terms of traffic generated.
 * [CSS Typeset](http://csstypeset.com/) - Visual typeset editor. Play around with font-face, word-spacing and other text attributes and download the corresponding CSS.
 * [pForm](http://www.phpform.org/) - Create HTML forms through a simple WYSIWYG GUI and download the corresponding code.


### PR DESCRIPTION
## Description

Added [Shopify Theme Detector](https://podifai.com/tools/shopify-theme-detector/) to the **Programming Tools** section.

## About the Tool

A free web-based tool to detect what Shopify theme any online store is using. Similar to how [BuildWith](https://builtwith.com/) identifies technology stacks, this tool specifically identifies Shopify themes.

- **No login required** — use immediately
- **No signup** — completely anonymous
- Supports batch URL analysis
- Detects 300+ themes including custom themes

**Link**: https://podifai.com/tools/shopify-theme-detector/

## Checklist

- [x] No login/signup required
- [x] Added to bottom of category as per CONTRIBUTING.md
- [x] Description ends with period
- [x] Spelling and grammar checked