### PR TITLE
Add VisaCanvas to Business and Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To save the world from creating user accounts and installing software applicatio
 * [TradingView.com](https://www.tradingview.com/) - Real-time information and market insights from various exchanges. Requires an account for saving settings.
 * [ICOStats.com](https://icostats.com/) - Track &amp; compare performance of ICOs. Displays detailed stats like ROI since ICO, ROI vs ETH since ICO, and charts for comparing the historical performance of ICOs.
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
+* [VisaCanvas](https://visacanvas.com) - Free AI-powered US immigration eligibility assessment for EB-1A and NIW visas.
 
 
 ### Communication


### PR DESCRIPTION
Added [VisaCanvas](https://visacanvas.com) to the Business and Finance section.

VisaCanvas is a free AI-powered tool that helps users assess their eligibility for US immigration visas (EB-1A and NIW). It works without requiring any login or account creation, making it a perfect fit for this list.

- No login required
- Free to use
- Provides instant AI-powered immigration eligibility assessment