### PR TITLE
Add DevToolBox to Programming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [DevToolBox](https://viadreams.cc) - 129+ free online developer tools including JSON formatter, Base64 encoder/decoder, JWT decoder, regex tester, hash generator, and more. All processing happens client-side.
 
 
 ### Search Engines


### PR DESCRIPTION
## Add DevToolBox to Programming Tools

Hi! I'd like to add [DevToolBox](https://viadreams.cc) to the **Programming Tools** section.

### What is DevToolBox?

DevToolBox is a collection of **129+ free online developer tools** that work entirely in the browser with **no login required**, including:

- JSON formatter/validator
- Base64 encoder/decoder
- JWT decoder
- Regex tester
- Hash generator (MD5, SHA-1, SHA-256)
- UUID generator
- URL encoder/decoder
- Color converter
- And 120+ more tools

### Why it fits this list

- **No login required** — fully anonymous usage
- **100% client-side** processing — no data is sent to any server
- Completely free, no ads
- Supports 15 languages
- Open source

**Website:** https://viadreams.cc

Thank you for maintaining this awesome list!