### PR TITLE
Add ReleaseRun DevOps Tools to Programming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [ReleaseRun DevOps Tools](https://releaserun.com/tools/) - 30 free browser-based tools for developers: dependency EOL scanner, vulnerability checker, Dockerfile linter, K8s upgrade simulator, JWT decoder, regex tester, and more. No signup required.
 
 
 ### Search Engines


### PR DESCRIPTION
Adding [ReleaseRun DevOps Tools](https://releaserun.com/tools/) to the Programming Tools section.

ReleaseRun offers free, no-account-required developer tools for DevOps and backend engineers. Tools include:

- Dependency EOL Scanner (package.json, requirements.txt, go.mod, Gemfile, etc.)
- CVE / Vulnerability Scanner (checks across multiple ecosystems)
- Dockerfile Security Linter (45+ rules)
- K8s Upgrade Simulator
- JWT Decoder & Inspector
- Regex Tester & Debugger
- YAML/JSON Converter
- CIDR/Subnet Calculator
- Nginx Config Generator
- And 20+ more

No login, no account required. Paste in your config or package file and get results instantly.

Website: https://releaserun.com/tools/