### PR TITLE
Add SBTI - Satirical Behavior Type Indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Morsify](https://morsify.net) - Online Morse code translator.
 * [Dub](https://dub.sh/) - Open-source link shortener.
 * [3dHousePlanner](https://www.3dhouseplanner.com/) - 3D home design application on the web.
+* [SBTI](https://sbti.support) - A satirical personality test parodying MBTI with 27 hilarious types, 30 questions, and 15-dimension analysis. Supports English, Chinese, Japanese, and Korean.
 -----
 
 ## License


### PR DESCRIPTION
## Add: SBTI - Satirical Behavior Type Indicator

**Link:** https://sbti.support

**Category:** Miscellaneous

**Description:** A satirical personality test parodying MBTI with 27 hilarious types, 30 questions, and 15-dimension analysis. Supports English, Chinese, Japanese, and Korean.

**Why it fits this list:**
- 100% free, no sign-up or login required
- Instant results after answering 30 fun questions
- No account needed to see your personality type, share results, or retake the test
- Multi-language support (EN/ZH/JA/KO)

This is a fun web app that works completely without any login — exactly what this awesome list is about.