### PR TITLE
Add KeyboardTester.click to Utilities — open-source browser hardware tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Randommer](https://randommer.io/) - Random data generator and validator.
 * [Meditation Timer](https://meditation.koti.cloud/) - A meditation timer to keep track of your sessions.
 * [Bucket Listy](https://bucketlisty.com/) - Bucket list manager with unique ideas where you can add your own.
-
+* [KeyboardTester.click](https://keyboardtester.click) - Free browser-based hardware diagnostic suite — keyboard, mouse, screen, webcam, mic, and audio testing with no install. Open source.
 
 ### Miscellaneous
 


### PR DESCRIPTION
Adds [KeyboardTester.click](https://keyboardtester.click) to the Utilities section.

**Why it fits this list:**
- 100% browser-based, no login or signup required
- All 90+ tools work without an account
- Open source: https://github.com/nasirazizawan009/keyboardtester-click
- Free, no ads on tool pages
- Covers keyboard testing (NKRO, polling rate, chatter detection), monitor testing
  (sharpness, ghosting, dead pixel), webcam, microphone, audio (frequency response,
  hearing age test), and various calculators (eDPI, FOV, RAM latency, bandwidth)

Placed at the bottom of Utilities (the section appears to be ordered chronologically, not alphabetically).
