### PR TITLE
Add SEC Filing Fee Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To save the world from creating user accounts and installing software applicatio
 * [TradingView.com](https://www.tradingview.com/) - Real-time information and market insights from various exchanges. Requires an account for saving settings.
 * [ICOStats.com](https://icostats.com/) - Track &amp; compare performance of ICOs. Displays detailed stats like ROI since ICO, ROI vs ETH since ICO, and charts for comparing the historical performance of ICOs.
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
+* [SEC Filing Fee Calculator](https://sec-filing-fee-calculator.vercel.app/) - Estimate SEC filing fees from aggregate amount or shares times price using the FY2026 rate, then copy a memo or EX-FILING-FEES CSV row without an account.
 
 
 ### Communication


### PR DESCRIPTION
Adds SEC Filing Fee Calculator to Business and Finance. It estimates SEC filing fees in the browser from aggregate amount or shares times price, and the core calculator works without login.