### PR TITLE
Add pdfmavericks.com (browser-local PDF tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Cloud Convert](https://cloudconvert.com/) - Convert from anything to anything including audio, video, font, document and lots more. Excellent integration with cloud storage services like Google Drive and Dropbox. Direct links.
 * [Online Convert](http://www.online-convert.com/) - Collection of audio, video, image, document, ebook and archive converter. No file size limits and direct download links upon conversion.
 * [PDF <=> EPUB](http://pdfepub.com/) - PDF to EPUB converter and vice versa.
+* [PDF Mavericks](https://pdfmavericks.com) - Browser-local PDF toolkit. Compress, merge, split, sign, watermark, redact, and convert PDFs without uploading. Processing runs entirely in JavaScript; files never leave your device.
 * [Pandoc Try](https://pandoc.org/try/) - Inter markup conversion using Pandoc. Supported - Latex, Markdown, HTML, RST and lots more.
 * [Print Friendly](https://www.printfriendly.com/) - Convert any webpage to simple format. Then download it or print as PDF.
 * [OnlineOCR](https://www.onlineocr.net/) - Convert a scanned PDF into DOC, XLS or TXT.


### PR DESCRIPTION
Adds [pdfmavericks.com](https://pdfmavericks.com) to File Converters.

pdfmavericks.com is a free, no-account toolkit for working with PDFs entirely in the browser — compress, merge, split, sign, watermark, redact, convert. Files never leave the device; the processing runs in JavaScript via PDF.js. No upload, no server, no tracking beyond anonymous usage analytics.

Hope this fits the list. Happy to adjust the entry text or section.