### PR TITLE
Add Postali — free postal codes API (Mexico, Colombia, Spain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [Postali](https://postali.app/api) - Free REST API for postal codes (códigos postales) in Mexico, Colombia, and Spain. No API key, no signup, no monthly quota. Eight endpoints for lookup, validation, fuzzy search, and bulk requests of up to 100 codes. HTTPS, CORS, JSON.
 
 
 ### Search Engines


### PR DESCRIPTION
Adds Postali under **Programming Tools**, alongside other developer-focused services like jsonstore.io.

[Postali](https://postali.app/api) is a public REST API for postal codes (códigos postales) covering Mexico, Colombia, and Spain. Truly no-login: no API key, no signup, no monthly request cap.

- Eight endpoints: lookup by code, existence validation, fuzzy search, listings by administrative level, bulk lookups (up to 100 per request)
- HTTPS-only, CORS open (`Access-Control-Allow-Origin: *`), JSON
- Cacheable lookups (`Cache-Control: public, s-maxage=604800`) — most traffic served from Cloudflare edge
- Sources: SEPOMEX (MX, ~157k entries), GeoNames (CO ~3.7k, ES ~38k)
- Documentation: https://postali.app/api/docs

Per CONTRIBUTING.md:
- [x] Read intro and confirmed addition is valid
- [x] Description ends with a full-stop
- [x] Added at the bottom of the Programming Tools section
- [x] Spelling and grammar checked