### PR TITLE
Add twineconvert to File Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To save the world from creating user accounts and installing software applicatio
 * [GifDeck](http://gifdeck.in/) - Convert slides from slideshare to GIF.
 * [favicon-generator](http://www.favicon-generator.org/) - Generate favicons for your web-apps or icons for your Android or iOS apps by uploading your desired image.
 * [freetools.site](https://freetools.site/) - Free online tools. Convert or edit documents, images, audio, video and more.
-
+* [twineconvert](https://twineconvert.com/) - 192 file converters that run entirely in the browser via WebAssembly. No upload, no signup, no file size limit. Covers HEIC/PDF/audio/video plus niches like Apple Health, Kindle clippings, GEDCOM, embroidery formats (DST/PES/JEF), ham radio (ADIF), bank statements (OFX/QFX/QBO).
 
 ### File Hosting/Sharing
 


### PR DESCRIPTION
Adding twineconvert. It fits the spirit of this list: zero login, zero signup, zero account, runs in the browser. Stronger than that, files don't even leave the device because every conversion is client-side WASM.

192 conversion tools across mainstream (HEIC, PDF, MP4, etc.) and niche (Apple Health export, Kindle clippings, GEDCOM, embroidery, ham radio, financial formats) format families.