### PR TITLE
Add Acento JWT Decoder under Programming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ To save the world from creating user accounts and installing software applicatio
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
 * [Mydentify AI Crawler Access Checker](https://mydentify.com/tools/ai-crawler-access-checker) - Checks robots.txt, page-level crawler directives, and responses to documented ChatGPT and Claude crawler user-agent names without login; it cannot verify official provider IPs.
+* [Acento JWT Decoder](https://www.acento.io/en/jwt-decoder/) - Decode and inspect JWT tokens (header, payload, signature) entirely in the browser; tokens are never sent to a server.
 
 
 ### Search Engines


### PR DESCRIPTION
Adds Acento JWT Decoder — decodes and inspects JWT tokens (header,
payload, signature) entirely in the browser. Tokens are never sent
to a server.

Differentiator: many online JWT decoders POST the token to a backend;
this one keeps the entire decoding flow client-side, which matters
when tokens contain sensitive claims.

- New entry placed at the bottom of "Programming Tools" per CONTRIBUTING.md
- Description ends with a full-stop
- No similar JWT entry currently in the list
