### PR TITLE
Add Base Pay Desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To save the world from creating user accounts and installing software applicatio
 * [TradingView.com](https://www.tradingview.com/) - Real-time information and market insights from various exchanges. Requires an account for saving settings.
 * [ICOStats.com](https://icostats.com/) - Track &amp; compare performance of ICOs. Displays detailed stats like ROI since ICO, ROI vs ETH since ICO, and charts for comparing the historical performance of ICOs.
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
+* [Base Pay Desk](https://oskarasi.github.io/base-pay-desk-site/) - Create shareable Base ETH checkout links from a seller wallet and offer details, with seller amount, platform fee, and buyer total shown before checkout.
 
 
 ### Communication


### PR DESCRIPTION
https://oskarasi.github.io/base-pay-desk-site/

Base Pay Desk is an accountless web app for creating shareable ETH-on-Base checkout links. Its core builder works without creating an account: enter a seller wallet, offer title, amount, fee bps, memo, and optional success URL, then copy the generated payment link and buyer message.

It fits Business and Finance because it is a lightweight checkout/payment-link tool for creators, agencies, and service sellers. Payment itself uses a wallet, but link generation does not require login. It is independent and not affiliated with Base, Coinbase, or official Base Pay.

- I have read the Contribution guidelines and I am confident that my PR is suitable.
- This pull request has a descriptive title.
- The app I added is not a duplicate.