### PR TITLE
Add WhatsApp Chat Formatter (File Converters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ To save the world from creating user accounts and installing software applicatio
 * [GifDeck](http://gifdeck.in/) - Convert slides from slideshare to GIF.
 * [favicon-generator](http://www.favicon-generator.org/) - Generate favicons for your web-apps or icons for your Android or iOS apps by uploading your desired image.
 * [freetools.site](https://freetools.site/) - Free online tools. Convert or edit documents, images, audio, video and more.
+* [WhatsApp Chat Formatter](https://xueboyang1985.github.io/whatsapp-chat-formatter/) - Format WhatsApp chat exports into Markdown, HTML, TXT, CSV, or JSON. 100% browser-based, no upload.
 
 
 ### File Hosting/Sharing

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Ambient Mixer](https://www.ambient-mixer.com/) - Listen to free audio atmospheres (e.g. Scottish Rain/Slytherin Common Room) or mix your own ambient sound online.
 * [Vileo](https://lukasbach.github.io/vileo/) - Record your screen or webcam and download the video from within your browser.
 * [Youtube Dynamic Playlists](https://youtube.ndo.dev) - Create on-the-fly playlists of YouTube videos.
+* [Subtitle Converter](https://xueboyang1985.github.io/subtitle-converter/) - Convert SRT, VTT, and ASS subtitles to TXT, Markdown, CSV, or JSON. 100% browser-based, no upload.
 
 
 ### Business and Finance
@@ -105,6 +106,7 @@ To save the world from creating user accounts and installing software applicatio
 * [PdfEscape](https://www.pdfescape.com/) - Edit or create PDFs in browser itself.
 * [Browserpad](http://browserpad.org/) - A server-less plain text editor in the browser. Allows you to open and save plain text files.
 * [WriteURL](http://www.writeurl.com/) - A collaborative real-time online text editor.
+* [Kindle Highlights Exporter](https://xueboyang1985.github.io/kindle-exporter/) - Export Kindle highlights and notes to Markdown, CSV, or JSON. 100% browser-based, no upload.
 
 
 <a name="drawing"></a>


### PR DESCRIPTION
## Add WhatsApp Chat Formatter

A browser-based tool that converts WhatsApp chat exports (.txt files) into Markdown, HTML, TXT, CSV, or JSON. 100% local - no upload, no signup, data never leaves your device.

- Auto-detects iOS and Android export formats
- Date range and sender filters
- Statistics dashboard
- Free for 100 messages, PRO for unlimited

https://xueboyang1985.github.io/whatsapp-chat-formatter/