### PR TITLE
Add Whisper Web (no-login browser transcription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Canvas Maker for Spotify Artists](https://spotifyedits.com) - Make a looping 9:16 Canvas video, artist header, avatar and cover art for a Spotify release. Encodes in the browser with WebCodecs, so files are never uploaded.
 * [Video Size Reducer](https://videosizereducer.org) - Compress MP4 videos right in your browser with the WebCodecs API; no upload, no account needed.
 * [audiotest.io](https://audiotest.io) - Free in-browser audio test toolkit with stereo left/right channel test, frequency sweep, tone generator, bass response test, headphone test and tinnitus frequency test. All tests run client-side, bilingual EN/ZH.
+* [Whisper Web](https://whisperweb.dev/) - Transcribe audio and video to text in the browser with OpenAI's Whisper. Runs on-device, no login, 100+ languages.
 
 
 ### Business and Finance


### PR DESCRIPTION
Adds [Whisper Web](https://whisperweb.dev/) to the Audio and Video section. It transcribes audio/video to text entirely in the browser using OpenAI's Whisper — no login, no install, runs on-device, supports 100+ languages. Fits the 'works without login' theme perfectly.