### PR TITLE
Add cv.cm

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Archive.org](https://archive.org/) `[Account]` - Unlimited file hosting of any type, no limits on bandwidth and upload size.
 * [MultCloud](https://www.multcloud.com/home) - Cloud service to manage, move, copy and migrate data between multiple cloud services. Supports all major cloud services. No sign-up required, 2TB cloud storage, download large files directly to the cloud, no size restrictions.
 * [harvis.dev](https://harvis.dev/) - Static website hosting without an account. Drag in a folder (or run `npx harvis`) and get a live site in seconds, with a private claim link to take ownership later. Free for small sites only.
+* [cv.cm](https://cv.cm/) - Paste text, images, audio, video or files and get an ultra-short link to share; with Markdown, code highlighting and auto-translation.
 
 
 <a name="games"></a>


### PR DESCRIPTION
Adds **cv.cm** to File Hosting/Sharing (appended to the bottom of the category, per CONTRIBUTING).

cv.cm is a fully no-login web app: paste text, images, audio, video or files and instantly get an ultra-short link to share or move content across devices — with Markdown, 200+ language code highlighting and auto-translation. Description ends with a full-stop, no `[Account]` tag needed (login-free).