### PR TITLE
Add PDF Toolbox to File Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To save the world from creating user accounts and installing software applicatio
 * [GifDeck](http://gifdeck.in/) - Convert slides from slideshare to GIF.
 * [favicon-generator](http://www.favicon-generator.org/) - Generate favicons for your web-apps or icons for your Android or iOS apps by uploading your desired image.
 * [freetools.site](https://freetools.site/) - Free online tools. Convert or edit documents, images, audio, video and more.
-
+* [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free online PDF tools (compress, merge, split, convert to/from JPG, Word, unlock, protect). All processing done locally in your browser. No upload required.
 
 ### File Hosting/Sharing
 


### PR DESCRIPTION
## Description

Add [PDF Toolbox](https://pdftoolbox-three.vercel.app) to the **File Converters** section.

PDF Toolbox is a free online PDF tool suite that processes files **entirely in the browser** — no upload required, no registration needed. It perfectly fits the spirit of this awesome list.

### Features:
- Compress PDF
- Merge PDF
- Split PDF
- PDF ↔ JPG conversion
- PDF to Word
- JPG to PDF
- Unlock PDF (remove password)
- Protect PDF (add password)

All tools work without login, without uploading files to any server. 100% client-side processing.