### PR TITLE
Add Tablesmit to Document editors - Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ To save the world from creating user accounts and installing software applicatio
 * [PdfEscape](https://www.pdfescape.com/) - Edit or create PDFs in browser itself.
 * [Browserpad](http://browserpad.org/) - A server-less plain text editor in the browser. Allows you to open and save plain text files.
 * [WriteURL](http://www.writeurl.com/) - A collaborative real-time online text editor.
-
+* [Tablesmit](https://tablesmit.com) - A minimalist table builder for analytical writing. Build, format, and export structured tables. No signup required.
 
 <a name="drawing"></a>
 ### Drawing


### PR DESCRIPTION
### Add Tablesmit

[Tablesmit](https://tablesmit.com) is a free, open-source, minimalist table builder for analytical writing. No signup or account required to use any feature.

**Why it fits:**
- Works entirely without login — no account needed
- All processing happens client-side (no server uploads)
- Open source (MIT): https://github.com/Olayiwola72/tablesmit
- Similar to existing entry EtherCalc (online spreadsheet editor)

**Key features:**
- Drag-to-resize columns and rows
- Merge cells, custom headers, column formatting
- Export to PDF, Excel, CSV, LaTeX, Markdown, HTML, and PNG
- Import from CSV and Excel
- Smart clipboard paste from spreadsheets
- Dark mode, 8-language i18n, keyboard shortcuts
- PWA with offline support