### PR TITLE
Add audiotest.io to Audio and Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Vileo](https://lukasbach.github.io/vileo/) - Record your screen or webcam and download the video from within your browser.
 * [Canvas Maker for Spotify Artists](https://spotifyedits.com) - Make a looping 9:16 Canvas video, artist header, avatar and cover art for a Spotify release. Encodes in the browser with WebCodecs, so files are never uploaded.
 * [Video Size Reducer](https://videosizereducer.org) - Compress MP4 videos right in your browser with the WebCodecs API; no upload, no account needed.
+* [audiotest.io](https://audiotest.io) - Free in-browser audio test toolkit with stereo left/right channel test, frequency sweep, tone generator, bass response test, headphone test and tinnitus frequency test. All tests run client-side, bilingual EN/ZH.
 
 
 ### Business and Finance


### PR DESCRIPTION
Adds [audiotest.io](https://audiotest.io) under **Audio and Video**.

A free in-browser audio test toolkit: stereo left/right channel test, frequency sweep, tone generator (sine/square/triangle), bass response test, headphone test and tinnitus frequency test. All tests run fully client-side using the Web Audio API. Bilingual EN/ZH.

- No login, no signup, no ads.
- No data leaves the browser (the audio engine is all client-side).
- Source: https://github.com/David-DL-Space/stereo-left-right-test (MIT)

Per CONTRIBUTING.md: added at the bottom of the Audio and Video category, description ends with a full-stop, no `[Account]` tag (no account anywhere on the site).