### PR TITLE
Add Jisuanqi 3000 to online calculators

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To save the world from creating user accounts and installing software applicatio
 * [TradingView.com](https://www.tradingview.com/) - Real-time information and market insights from various exchanges. Requires an account for saving settings.
 * [ICOStats.com](https://icostats.com/) - Track &amp; compare performance of ICOs. Displays detailed stats like ROI since ICO, ROI vs ETH since ICO, and charts for comparing the historical performance of ICOs.
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
+* [Jisuanqi 3000](https://jsq3000.com) - Free China-localized calculators for mortgage, income tax, salary, auto purchase cost, compound interest, BMI, and more. No login required.
 
 
 ### Communication


### PR DESCRIPTION
Adds Jisuanqi 3000, a free China-localized online calculator site covering mortgage, income tax, take-home salary, auto purchase cost, compound interest, BMI, body fat, and more. The calculator pages include formulas, source references, and update dates.