### PR TITLE
Add Picute Subtitle Converter to File Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ To save the world from creating user accounts and installing software applicatio
 * [GifDeck](http://gifdeck.in/) - Convert slides from slideshare to GIF.
 * [favicon-generator](http://www.favicon-generator.org/) - Generate favicons for your web-apps or icons for your Android or iOS apps by uploading your desired image.
 * [freetools.site](https://freetools.site/) - Free online tools. Convert or edit documents, images, audio, video and more.
+* [Picute Subtitle Converter](https://picute.net/en/tools/srt-to-vtt-converter) - Convert subtitle files between SRT and VTT formats in the browser. No upload, no login.
 
 
 ### File Hosting/Sharing


### PR DESCRIPTION
Adds **Picute Subtitle Converter** to **File Converters** — a free, no-login web app that converts subtitle files between SRT and VTT formats entirely in the browser (nothing is uploaded). The section has general converters (CloudConvert, Online Convert) but no dedicated subtitle-format converter, so this fills a small gap.

- Added at the bottom of the File Converters category, following the list style.
- No `[Account]` tag — the tool works fully without login.

Disclosure: I'm affiliated with Picute.
