### PR TITLE
Add DevLab to Programming Tools — 20+ free dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [DevLab](https://devlab.tools/) - Collection of 20+ free developer tools: regex tester, JSON formatter/validator, JWT decoder, Base64, hash generator, URL encoder, color converter, text diff, and more — all without login or signup.
 
 
 ### Search Engines


### PR DESCRIPTION
## What this adds

**[DevLab](https://devlab.tools/)** — A collection of 20+ free developer tools that work directly in the browser, no login or signup required.

Tools included:
- **Encoding/Decoding**: Base64, URL encoder/decoder, JWT decoder
- **JSON**: formatter, validator, minifier, JSON-to-TypeScript
- **Text**: word counter, case converter, text diff, markdown previewer
- **Code**: regex tester (with live match highlighting), hash generator (MD5/SHA-1/SHA-256), HTML beautifier
- **CSS**: gradient generator, color converter
- **Data**: Unix timestamp converter, number base converter, OpenAPI diff, DB schema diff

All tools work client-side. No account needed.

Fits in the `### Programming Tools` section alongside JsonFormatter and Regulex.