### PR TITLE
Add Folicle hair self-checks to Utilities (uncategorized)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Randommer](https://randommer.io/) - Random data generator and validator.
 * [Meditation Timer](https://meditation.koti.cloud/) - A meditation timer to keep track of your sessions.
 * [Bucket Listy](https://bucketlisty.com/) - Bucket list manager with unique ideas where you can add your own.
+* [Folicle Hair Self-Checks](https://folicle.app/tools) - Free Norwood scale, Ludwig scale and hair-shedding self-check calculators that run entirely in the browser with no signup.
 
 
 ### Miscellaneous


### PR DESCRIPTION
Adds Folicle's free hair self-check tools under **Utilities (uncategorized)**.

They fit the list's core rule — everything runs **entirely in the browser with no login/account**: a Norwood scale self-check, a Ludwig scale self-check, and a hair-shedding checker (all client-side React, no signup, no paywall).

Added to the bottom of the category, single line, description ends with a full stop, per CONTRIBUTING.md.