### PR TITLE
Add ToolBox Pro to Programming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [ToolBox Pro](https://dingpeng29.github.io/) - Free online developer toolbox with 25+ tools: PDF toolkit, image compressor, JSON formatter, QR decoder, resume builder, password generator, text toolkit, and more. All run locally in the browser, no login required.
 
 
 ### Search Engines


### PR DESCRIPTION
## Description
Add [ToolBox Pro](https://dingpeng29.github.io/) to the Programming Tools section.

ToolBox Pro is a free online developer toolbox with 25+ tools including:
- PDF toolkit (merge, split, extract pages)
- Image compressor (JPG/PNG/WebP)
- JSON formatter and validator
- QR code decoder
- Resume builder
- Password/UUID generators
- Text toolkit (word count, case convert, simplified/traditional Chinese)
- Timestamp converter, YAML-JSON converter, SQL formatter, and more

All tools run locally in the browser. No login or account required.

## Checklist
- [x] Added entry to Programming Tools section
- [x] Follows existing format `[Name](url) - Description.`
- [x] App works without login