### PR TITLE
Add JotTools to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Randommer](https://randommer.io/) - Random data generator and validator.
 * [Meditation Timer](https://meditation.koti.cloud/) - A meditation timer to keep track of your sessions.
 * [Bucket Listy](https://bucketlisty.com/) - Bucket list manager with unique ideas where you can add your own.
+* [JotTools](https://jottools.com) - Suite of 130+ single-purpose tools (PDF, image, text, color, calculators, developer utilities) that all run client-side with nothing uploaded; individual tools are basic rather than advanced.
 
 
 ### Miscellaneous


### PR DESCRIPTION
Adds [JotTools](https://jottools.com) to the Utilities section. It is a suite of 130+ single-purpose tools (PDF, image, text, color, calculators, developer utilities) that all run fully client-side in the browser with no login and nothing uploaded to a server. Follows the contributing guidelines: added at the bottom of the category, description notes both features and the trade-off, ends with a full stop.