### PR TITLE
Add QuickImageHub (client-side image & PDF tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ To save the world from creating user accounts and installing software applicatio
 * [GifDeck](http://gifdeck.in/) - Convert slides from slideshare to GIF.
 * [favicon-generator](http://www.favicon-generator.org/) - Generate favicons for your web-apps or icons for your Android or iOS apps by uploading your desired image.
 * [freetools.site](https://freetools.site/) - Free online tools. Convert or edit documents, images, audio, video and more.
+* [QuickImageHub](https://quickimagehub.com/) - 85+ image and PDF tools (convert, compress, resize, merge, split, OCR). All processing happens in the browser, so files never leave your device and there are no file size or usage limits. No cloud storage integrations.
 
 
 ### File Hosting/Sharing


### PR DESCRIPTION
Adds QuickImageHub to File Converters (bottom of category, per guidelines).

It's a free browser-based toolkit with 85+ image and PDF tools. Everything runs client-side, so files are never uploaded, there is no login, and no file size or usage limits. Shortcoming noted in the description: no cloud storage integrations.

Disclosure: I'm the developer.