### PR TITLE
Add Excel to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ To save the world from creating user accounts and installing software applicatio
 * [GifDeck](http://gifdeck.in/) - Convert slides from slideshare to GIF.
 * [favicon-generator](http://www.favicon-generator.org/) - Generate favicons for your web-apps or icons for your Android or iOS apps by uploading your desired image.
 * [freetools.site](https://freetools.site/) - Free online tools. Convert or edit documents, images, audio, video and more.
+* [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Convert XLSX, XLS, and CSV files into Markdown tables locally in the browser; no account or server upload required.
 
 
 ### File Hosting/Sharing


### PR DESCRIPTION
**https://exceltomd.com/excel-to-markdown**

**Excel to Markdown converts spreadsheet files into Markdown tables without requiring an account. Its core conversion runs locally in the browser, so files are not uploaded; this gives the list a privacy-focused spreadsheet-to-Markdown option not currently covered by the generic converters. Disclosure: I built and operate the app.**

# By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the Contribution guidelines and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title.
- [x] The app I added is not a duplicate.