### PR TITLE
Add Crossbill to Business and Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To save the world from creating user accounts and installing software applicatio
 * [TradingView.com](https://www.tradingview.com/) - Real-time information and market insights from various exchanges. Requires an account for saving settings.
 * [ICOStats.com](https://icostats.com/) - Track &amp; compare performance of ICOs. Displays detailed stats like ROI since ICO, ROI vs ETH since ICO, and charts for comparing the historical performance of ICOs.
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
+* [Crossbill](https://getcrossbill.com) - Create VAT/GST-compliant invoices and quotes with built-in tax presets for the UK, EU, Australia and more. No signup; runs entirely in your browser.
 
 
 ### Communication


### PR DESCRIPTION
Adds Crossbill (https://getcrossbill.com) — a free, no-login web app that creates VAT/GST-compliant invoices and quotes entirely in the browser (data never leaves the device). Fits alongside InvoiceToMe in the Business and Finance section.