### PR TITLE
Add OnlyAI.FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Anime Openings](http://openings.moe/) - Free anime radio, listen or download anime opening and ending videos.
 * [NoteFlight](https://www.noteflight.com/login) `[Account]` - Print music sheets, write your own music online (review).
 * [ongaku](https://ongaku.js.org/) - Online anime music radio, with [desktop port](https://github.com/Anshuman-Verma/ongaku-desktop).
+* [OnlyAI.FM](https://onlyai.fm/) - Free browser-based AI music radio with genre discovery, charts and creator profiles; listening works without an account, while uploads and saved interactions require one.
 * [Radio Garden](http://radio.garden/) - Listen to thousands of radio stations worldwide by selecting a city on the globe.
 
 


### PR DESCRIPTION
Adds [OnlyAI.FM](https://onlyai.fm/) to **Music, Radio and Podcasts**.

- Core listening, genre browsing, charts, and creator profiles work without login.
- An account is needed only for uploads and saved interactions.
- The public site was checked live on 2026-07-22.

Disclosure: I operate the project.