### PR TITLE
Add Toolbin to Programming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [Toolbin](https://toolbin.dev) - 270+ in-browser developer tools (JSON, Base64, JWT, hashing, converters, regex, images, code playground). No signup, in 6 languages.
 
 
 ### Search Engines


### PR DESCRIPTION
Adds [Toolbin](https://toolbin.dev) under **Programming Tools**.

Toolbin is a free collection of 270+ developer tools (JSON/CSV/YAML converters, Base64, JWT, hashing & crypto, regex tester, image tools, a JS/TS/Python/PHP code playground, and more). It runs **100% in the browser** with **no login/signup** and is available in 6 languages (EN/FR/ES/DE/PT/IT) — a good fit for this list.

Entry follows the guidelines: added at the bottom of the category, description ends with a full-stop.