### PR TITLE
Add Video Size Reducer to Audio and Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Ambient Mixer](https://www.ambient-mixer.com/) - Listen to free audio atmospheres (e.g. Scottish Rain/Slytherin Common Room) or mix your own ambient sound online.
 * [Vileo](https://lukasbach.github.io/vileo/) - Record your screen or webcam and download the video from within your browser.
 * [Canvas Maker for Spotify Artists](https://spotifyedits.com) - Make a looping 9:16 Canvas video, artist header, avatar and cover art for a Spotify release. Encodes in the browser with WebCodecs, so files are never uploaded.
+* [Video Size Reducer](https://videosizereducer.org) - Compress MP4 videos right in your browser with the WebCodecs API; no upload, no account needed.
 
 
 ### Business and Finance


### PR DESCRIPTION
Adds [Video Size Reducer](https://videosizereducer.org) to the Audio and Video section.

It's a free browser-based MP4 compressor built on the WebCodecs API — videos are processed entirely locally in the browser (no upload, no account, no watermark). Fits the list's no-login criterion perfectly. Pick a target size or quality preset and download a smaller file.

Single-line addition following the existing '* [Name](url) - description.' format.