### PR TITLE
Add DevTools Hub to Programming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [DevTools Hub](https://chaiwatce.github.io/devtools-hub/) - 9 client-side developer utilities (JSON formatter, JWT decoder, Base64, UUID generator, and more) in one static site. Open source.
 
 
 ### Search Engines


### PR DESCRIPTION
Adds [DevTools Hub](https://chaiwatce.github.io/devtools-hub/), a static, zero-dependency suite of 9 client-side developer utilities (JSON formatter, JWT decoder, Base64 encode/decode, UUID generator, and more). No login, no backend, no tracking — fits the list's theme directly. Source: https://github.com/chaiwatce/devtools-hub