### PR TITLE
Add Mydentify AI Crawler Access Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [Mydentify AI Crawler Access Checker](https://mydentify.com/tools/ai-crawler-access-checker) - Checks robots.txt, page-level crawler directives, and responses to documented ChatGPT and Claude crawler user-agent names without login; it cannot verify official provider IPs.
 
 
 ### Search Engines


### PR DESCRIPTION
**https://mydentify.com/tools/ai-crawler-access-checker**

**Mydentify AI Crawler Access Checker is a free web utility that works without an account. It checks robots.txt, page-level crawler directives, and the HTTP responses returned when a page is requested using documented ChatGPT and Claude crawler user-agent names. The entry also states its principal limitation: it cannot verify that a request originated from an official provider IP. It fits Programming Tools alongside the existing website testing and SEO utilities. I maintain Mydentify and am disclosing that relationship directly.**

# By submitting this pull request I confirm I have read and complied with the below requirements.

- [x] I have read the Contribution guidelines and am confident that this PR is suitable.
- [x] This pull request has a descriptive title.
- [x] The app is not a duplicate.