### PR TITLE
Add harvis.dev to File Hosting/Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ To save the world from creating user accounts and installing software applicatio
 * [SendVid](https://sendvid.com/) - Video hosting service.
 * [Archive.org](https://archive.org/) `[Account]` - Unlimited file hosting of any type, no limits on bandwidth and upload size.
 * [MultCloud](https://www.multcloud.com/home) - Cloud service to manage, move, copy and migrate data between multiple cloud services. Supports all major cloud services. No sign-up required, 2TB cloud storage, download large files directly to the cloud, no size restrictions.
+* [harvis.dev](https://harvis.dev/) - Static website hosting without an account. Drag in a folder (or run `npx harvis`) and get a live site in seconds, with a private claim link to take ownership later. Free for small sites only.
 
 
 <a name="games"></a>


### PR DESCRIPTION
Adds [harvis.dev](https://harvis.dev/) to File Hosting/Sharing.

**Why it fits this list:** publishing a static website normally requires an account everywhere (Netlify, Vercel, GitHub Pages). harvis.dev works with no login at all — drag a folder into the browser (or run `npx harvis`) and the site is live at `slug.harvis.dev` in seconds. Each anonymous deploy returns a private claim link, so an account is optional and only needed if you later want to manage the site. Main shortcoming noted in the description: the free tier is for small sites.

Disclosure: I built harvis.dev. Added at the bottom of the category per the contributing guidelines.