### PR TITLE
Add ShiftDispatch Schedule Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ To save the world from creating user accounts and installing software applicatio
 * [TradingView.com](https://www.tradingview.com/) - Real-time information and market insights from various exchanges. Requires an account for saving settings.
 * [ICOStats.com](https://icostats.com/) - Track &amp; compare performance of ICOs. Displays detailed stats like ROI since ICO, ROI vs ETH since ICO, and charts for comparing the historical performance of ICOs.
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
+* [ShiftDispatch Schedule Builder](https://shiftdispatchhq.com/schedule-builder) - Build weekly staff schedules, import or export spreadsheets, print schedules, and optionally publish a read-only link without creating an account.
 
 
 ### Communication


### PR DESCRIPTION
**https://shiftdispatchhq.com/schedule-builder**

**ShiftDispatch Schedule Builder lets managers build weekly staff schedules, import or export spreadsheets, print schedules, and optionally publish a read-only link. Its core scheduling workflow works without creating an account.**

# By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the [Contribution guidelines](https://github.com/aviaryan/awesome-no-login-web-apps/blob/master/CONTRIBUTING.md) and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title.
- [x] The app I added is not a duplicate.

## Verification

- Confirmed the schedule builder opens and its core workflow does not require login.
- Confirmed the entry is at the bottom of Business and Finance and ends with a full-stop.