### PR TITLE
Add Double Cross to Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ To save the world from creating user accounts and installing software applicatio
 * [nitrome](https://www.nitrome.com/) - Collection of free pixelart games. New games doesn't require flash.
 * [Orion](https://orion.lukasbach.com/) - Board/puzzle game. Cleverly combine tiles from bags to fill up the board.
 * [Gidd.io](https://gidd.io/) - Collection of classic games like UNO, Yatzy, Scattergories and GeoGuess.
+* [Double Cross](https://everhall.ca) - A daily crossword where every clue has two answers of equal length; deduce which twin slot gets which, then seal the grid once. No ads or tracking, one static page.
 
 ### Graphics, Image and Design
 


### PR DESCRIPTION
Adding [Double Cross](https://everhall.ca) — a free daily crossword variant where every clue has two answers of equal length and you deduce which twin slot each belongs in from the crossing letters, then seal the grid in one press.

Fits this list exactly: no login, no account, no ads, no tracking — the whole game is one static HTML page. A new machine-verified puzzle every day.

Disclosure: I'm the maker.