### PR TITLE
Add ImgSplit to Graphics, Image and Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ To save the world from creating user accounts and installing software applicatio
 * [CleanIcons](https://cleanicons.xyz) - Download Font Awesome icon fonts as PNG's.
 * [Mancer](https://mancer.app) - Design, share, and order T-Shirts from the browser. Designs can be exported as PNGs.
 * [Branition Colors](https://branition.com/colors) - Hand-curated collection of color pallets best fitted for branding.
+* [ImgSplit](https://imgsplit.com/) - Privacy-first image toolkit for splitting, grids, compression, watermarks, and local background removal. Images stay in the browser.
 
 
 ### Internet Downloaders


### PR DESCRIPTION
Adds [ImgSplit](https://imgsplit.com/) at the bottom of **Graphics, Image and Design** (per CONTRIBUTING).

ImgSplit is a free, MIT-licensed, in-browser image toolkit (grid/carousel split, compression, watermarks, local background removal). Core features work without an account; images are not uploaded.

Disclosure: I maintain this project ([ZooHero500/imgsplit](https://github.com/ZooHero500/imgsplit)). Not affiliated with splitimg.com or @imgsplit/core.