### PR TITLE
Add MetadataRemover.ai to privacy tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ To save the world from creating user accounts and installing software applicatio
 * [10 Minute Mail](https://10minutemail.com/10MinuteMail/index.html) - A temporary fully functional email address for 10 minutes (extendible).
 * [BugMeNot](http://bugmenot.com/) - A platform for finding and sharing logins of different websites. It helps you find credentials for signing in into different websites.
 * [Cloverleaf](https://cloverleaf.app) - An open source app to replace your password manager without storing your passwords anywhere.
+* [MetadataRemover.ai](https://metadataremover.ai/) - Inspect, edit, remove, and verify supported metadata in images, PDFs, DOCX files, videos, and MP3 audio locally in the browser; no account required.
 
 ### Programming Editors and IDEs
 


### PR DESCRIPTION
## Summary

- add MetadataRemover.ai to Privacy, Security and Cryptography
- document its local browser workflow and no-account requirement

Disclosure: I maintain MetadataRemover.ai.