### PR TITLE
Add WorkroomCalc to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Resume Nation](https://resume-nation.github.io) - An open source resume builder progressive web app which can work offline. It has a few themes to choose from and it can export the resume in PDF form.
 * [Daily Todo](https://dailytodo.org/) -  Simple todo list maker.
 * [Mailinator](https://www.mailinator.com/) - Disposable email service.
+* [WorkroomCalc](https://workroomcalc.co.uk/) - Free in-browser Roman blind calculator for fabric, lining, rods and cord. No signup.
 * [Randommer](https://randommer.io/) - Random data generator and validator.
 * [Meditation Timer](https://meditation.koti.cloud/) - A meditation timer to keep track of your sessions.
 * [Bucket Listy](https://bucketlisty.com/) - Bucket list manager with unique ideas where you can add your own.


### PR DESCRIPTION
## Summary
- Add WorkroomCalc under Utilities (uncategorized).
- Free in-browser Roman blind calculator. No signup.

## Test plan
- [ ] Link resolves
- [ ] Format matches existing Utilities entries