### PR TITLE
Add Random Animal Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Directed Grap Editor (CS Academy)](https://csacademy.com/app/graph_editor/) - Draw directed graph systems with and without edge values and physics.
 * [Abc-Map](https://abc-map.fr) - Create geographical maps, pick data from the data store, process data to create visualizations, export or share your maps online. 
 * [KeepFormula](https://keepformula.github.io/) - Keep Formula is a simple app to make your calculations easier.
+* [Random Animal Picker](https://randomanimalpicker.com/) - Discover real animals through photos, concise facts, source links, and related species without creating an account.
 
 
 <a name="text-tools"></a>


### PR DESCRIPTION
## What this adds\n\n- Adds Random Animal Picker to the Study and Education section.\n- The app provides a no-account animal discovery experience with photos, concise facts, source links, and related species.\n\nThe site is publicly available at https://randomanimalpicker.com/ and the core experience works without an account.