### PR TITLE
Add DeepSeek酱语录 — meme gallery (Graphics, Image and Design)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ To save the world from creating user accounts and installing software applicatio
 * [CleanIcons](https://cleanicons.xyz) - Download Font Awesome icon fonts as PNG's.
 * [Mancer](https://mancer.app) - Design, share, and order T-Shirts from the browser. Designs can be exported as PNGs.
 * [Branition Colors](https://branition.com/colors) - Hand-curated collection of color pallets best fitted for branding.
+* [DeepSeek酱语录](https://ai-meme.cdqyfdbymn.me/) - Meme gallery of DeepSeek whale-girl (AI 娘化) stickers with quote captions. Waterfall browsing, tag filters, dark mode and share-card export, no login needed.
 
 
 ### Internet Downloaders


### PR DESCRIPTION
Adds [DeepSeek酱语录](https://ai-meme.cdqyfdbymn.me/) to **Graphics, Image and Design**.

A free, no-login web gallery of 128 DeepSeek whale-girl memes with quote-level captions — waterfall browsing, tag filters, dark mode, and one-click share-card export. Works fully client-side on static hosting.

Thanks for reviewing!