### PR TITLE
Add WeGoWhen to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Randommer](https://randommer.io/) - Random data generator and validator.
 * [Bucket Listy](https://bucketlisty.com/) - Bucket list manager with unique ideas where you can add your own.
 * [Folicle Hair Self-Checks](https://folicle.app/tools) - Free Norwood scale, Ludwig scale and hair-shedding self-check calculators that run entirely in the browser with no signup.
+* [WeGoWhen](https://wegowhen.com) - Finds the dates a group can travel together: everyone taps the days they are free and it ranks the consecutive date ranges that fit the most people. Days only, so no time-of-day scheduling.
 
 
 ### Miscellaneous


### PR DESCRIPTION
Adds one entry at the bottom of **Utilities (uncategorized)**:

> * [WeGoWhen](https://wegowhen.com) - Finds the dates a group can travel together: everyone taps the days they are free and it ranks the consecutive date ranges that fit the most people. Days only, so no time-of-day scheduling.

Why it fits: no account, no email address, nothing to install, for the organiser or the participants. Identity is a name you type plus the link you were sent, and every core feature works without login.

Followed CONTRIBUTING: added at the bottom of the category, description ends with a full stop, and it names the shortcoming (no time-of-day dimension at all, so it is not a meeting scheduler).

Disclosure: I built it.