### PR TITLE
Add Procrastination Cost Calculator to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Randommer](https://randommer.io/) - Random data generator and validator.
 * [Meditation Timer](https://meditation.koti.cloud/) - A meditation timer to keep track of your sessions.
 * [Bucket Listy](https://bucketlisty.com/) - Bucket list manager with unique ideas where you can add your own.
+* [Procrastination Cost Calculator](https://silentoverseer.com/procrastination-cost-calculator/) - Converts hours lost to procrastination into a weekly/monthly/yearly cost in money and time. Client-side only, nothing stored or sent to a server.
 
 
 ### Miscellaneous


### PR DESCRIPTION
Adding a small free tool under Utilities. It's a client-side-only calculator (no backend, no signup, nothing transmitted or stored) that turns procrastination into a concrete cost figure. Happy to adjust wording/section placement per your conventions -- let me know if you'd place it elsewhere.

https://silentoverseer.com/procrastination-cost-calculator/

The Procrastination Cost Calculator converts hours lost to procrastination into a weekly/monthly/yearly cost in money and time. It runs entirely client-side (no login, nothing sent to or stored on a server), matching this list's own inclusion criteria directly, and is offered under Utilities (uncategorized) since it doesn't fit an existing category.

By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the Contribution guidelines and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title.
- [x] The app I added is not a duplicate.