### PR TITLE
feat: add AETHERIUS Control Room — 40 live x402 APIs, no signup, in-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ To save the world from creating user accounts and installing software applicatio
 * [ObjGen](http://www.objgen.com/) - This app helps you generate code (JSON, HTML, etc) in real time as you type in only the key words, types and properties using a text based syntax.
 * [JsonFormatter](https://jsonformatter.curiousconcept.com) - View json in human readable form.
 * [DebugBear Speed Test](https://www.debugbear.com/test/website-speed) - Test site speed and Core Web Vitals.
+* [AETHERIUS Control Room](https://wilnowilx.github.io/aetheriusxapi/dashboard/) - Explore and test 40 live x402 APIs with no signup — interactive catalog + explorer + real telemetry. Open-source (MIT).
 
 
 ### Search Engines


### PR DESCRIPTION
### Add AETHERIUS Control Room

**URL:** https://wilnowilx.github.io/aetheriusxapi/dashboard/
**Repo:** https://github.com/wilnowilx/aetheriusxapi (MIT)
**Section:** Programming Tools

**What it is:**
Explore and test **40 live x402 APIs** (maps, token, web, data, drift, DeFi, forex, news) directly from the browser. Interactive catalog + explorer with param forms + real server telemetry.

**Why it fits:**
- **No signup — actually.** Open the dashboard, pick an endpoint, hit Execute. Local mode (`X-PAYMENT: dashboard-demo`) is free with no account; testnet mode settles real USDC on Base Sepolia via x402 (wallet is the identity).
- **Most core features work without login.** Catalog, explorer, live metrics — all usable instantly. No install.
- **Open-source.** MIT: https://github.com/wilnowilx/aetheriusxapi
- **Live & verifiable.** 40 endpoints, 60/60 tests, public `/v1/telemetry`, demo video of 402 → 200 flow.

One-liner as in README:
> Explore and test 40 live x402 APIs with no signup — interactive catalog + explorer + real telemetry. Open-source (MIT).

Thanks for curating!
