### PR TITLE
Add Canvas Maker for Spotify Artists (Audio and Video)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Ambient Mixer](https://www.ambient-mixer.com/) - Listen to free audio atmospheres (e.g. Scottish Rain/Slytherin Common Room) or mix your own ambient sound online.
 * [Vileo](https://lukasbach.github.io/vileo/) - Record your screen or webcam and download the video from within your browser.
 * [Youtube Dynamic Playlists](https://youtube.ndo.dev) - Create on-the-fly playlists of YouTube videos.
+* [Canvas Maker for Spotify Artists](https://spotifyedits.com) - Make a looping 9:16 Canvas video, artist header, avatar and cover art for a Spotify release. Encodes in the browser with WebCodecs, so files are never uploaded.
 
 
 ### Business and Finance


### PR DESCRIPTION
A free browser tool that makes the visuals a Spotify release needs: a looping 9:16 Canvas video (3–8 s, 1080×1920), an artist header 2660×1140, an avatar 750×750, cover art and playlist covers.

Fits this list because there is genuinely no login anywhere in it — no account, no email, no trial. Encoding runs locally through WebCodecs, so files are never uploaded; you can watch the Network tab stay empty while it exports.

Built by an independent artist for their own releases. Free, no watermark, no export limit.