### PR TITLE
Add Table Party to Games

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ To save the world from creating user accounts and installing software applicatio
 * [nitrome](https://www.nitrome.com/) - Collection of free pixelart games. New games doesn't require flash.
 * [Orion](https://orion.lukasbach.com/) - Board/puzzle game. Cleverly combine tiles from bags to fill up the board.
 * [Gidd.io](https://gidd.io/) - Collection of classic games like UNO, Yatzy, Scattergories and GeoGuess.
+* [Table Party](https://tableparty.io/) - Free browser party games. One person hosts, friends join with a room code on their phones. No ads, no accounts.
 
 ### Graphics, Image and Design
 


### PR DESCRIPTION
Adds [Table Party](https://tableparty.io/) under Games — free browser party games that work with no account (host shares a room code; friends join on their phones).

Fits the list: core features work without signup, same category as skribbl.io and Gidd.io.