### PR TITLE
Add Clipboard Table to File Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ To save the world from creating user accounts and installing software applicatio
 * [freetools.site](https://freetools.site/) - Free online tools. Convert or edit documents, images, audio, video and more.
 * [Excel to Markdown](https://exceltomd.com/excel-to-markdown) - Convert XLSX, XLS, and CSV files into Markdown tables locally in the browser; no account or server upload required.
 * [Picute Subtitle Converter](https://picute.net/en/tools/srt-to-vtt-converter) - Convert subtitle files between SRT and VTT formats in the browser. No upload, no login.
+* [Clipboard Table](https://tevinch.github.io/data-shape-kit/) - Convert pasted spreadsheet TSV to JSON locally, preserving quoted line breaks, empty cells and leading zeros as strings. Text input only; no XLSX import.
 
 
 ### File Hosting/Sharing


### PR DESCRIPTION
**[Clipboard Table](https://tevinch.github.io/data-shape-kit/)**

**Clipboard Table converts pasted spreadsheet TSV into downloadable JSON in the browser, with no account or server upload. It preserves quoted line breaks, empty cells and leading zeros as strings. It accepts pasted text only, not XLSX files.**

I maintain this free MIT-licensed tool. The link opens the converter directly. This adds one entry at the bottom of File Converters; I checked the current list and existing pull requests for duplicates.

# By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the [Contribution guidelines](https://github.com/aviaryan/awesome-no-login-web-apps/blob/master/CONTRIBUTING.md) and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title. For example, `Add [App name]`, not `Update readme.md` or `Added new entries`.
- [x] The app I added is not a duplicate.
