### PR TITLE
Add StudyArena to Study and Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Abc-Map](https://abc-map.fr) - Create geographical maps, pick data from the data store, process data to create visualizations, export or share your maps online. 
 * [KeepFormula](https://keepformula.github.io/) - Keep Formula is a simple app to make your calculations easier.
 * [Random Animal Picker](https://randomanimalpicker.com/) - Discover real animals through photos, concise facts, source links, and related species without creating an account.
+* [StudyArena](https://studyarena.com) - Compare three AI answers to a study question without signing up; vote, then reveal the models for free.
 
 
 <a name="text-tools"></a>


### PR DESCRIPTION
**https://studyarena.com**

**I'm one of the people building StudyArena. Students can ask a question, compare three anonymous AI answers, and vote before revealing the models without signing up. That core flow is free; choosing models and comparing six answers requires the paid Supporter plan. It fits Study and Education as another way to explore explanations of a question.**

# By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the contribution guidelines and checked that this app fits the list.
- [x] This pull request has a descriptive title.
- [x] The app is not a duplicate; I searched files and open and closed issues and PRs for its name and both domains.

I added the entry at the bottom of Study and Education and checked the link with `awesome_bot`: it passes. The repository-wide `bash test.sh` fails on the unchanged upstream with 15 existing link issues, including dead links and access errors. `git diff --check` passes for this entry.
