### PR TITLE
Add Wheelwise (UK no-login used-car price check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ To save the world from creating user accounts and installing software applicatio
 * [Dub](https://dub.sh/) - Open-source link shortener.
 * [3dHousePlanner](https://www.3dhouseplanner.com/) - 3D home design application on the web.
 * [Luna Tarot](https://www.lunatarotapp.com) - Free multilingual tarot reading web app with 8-language support, daily readings, meditation music, and moon calendar.
+* [Wheelwise](https://trothstone.com/) - UK used-car price check with no account: every advert gets a fair-price grade (A-E), a 36-month resale forecast and a true monthly cost of ownership. Methodology and error bars published. UK-only.
 -----
 
 ## License


### PR DESCRIPTION
Adds Wheelwise under **Miscellaneous** - happy to move it if a category fits better.

**What it is:** a free, no-login UK used-car price-check tool. Search the built-in 417,146-listing index (or paste any live UK advert) and it grades the asking price against a fair-price model (A-E), forecasts resale at 24/36/48 months, and computes true monthly cost of ownership (depreciation + finance + fees). It also compares 577 live UK lease deals against buying outright.

**Why it fits this list:** every consumer feature works with zero registration, cookies, or account.

**Honest notes / limitations:**
- UK-only (rule 13): listings are UK adverts in GBP. I put it in Miscellaneous per the CONTRIBUTING guidance for region-specific apps; happy to rework this PR to create a Region/Country-Specific section instead.
- No public API docs; the JSON endpoints the site itself uses are open but undocumented.
- CORS: not enabled (no Access-Control-Allow-Origin on responses) - fine for the web app, but third-party embedding would need a proxy.

**Verifiable at time of posting** (live figures, checked 2026-09-10):
- /api/stats reports n=417,146 graded listings across 78 makes
- Methodology page publishes model error openly: holdout RMSLE 0.161 at https://trothstone.com/methodology/
- Lease index: 577 live deals

Maintainer of the site here - any corrections welcome.