### PR TITLE
Add Perpiece wholesale-order calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To save the world from creating user accounts and installing software applicatio
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
 * [ShiftDispatch Schedule Builder](https://shiftdispatchhq.com/schedule-builder) - Build weekly staff schedules, import or export spreadsheets, print schedules, and optionally publish a read-only link without creating an account.
 * [QuoteChime](https://quotechime.pages.dev/?ref=awesomenologin#generator) - Draft a finite quote follow-up sequence for service businesses in the browser. It does not send messages or store customer details.
+* [Perpiece](https://perpiece.aifirm.app/?utm_source=github&utm_medium=directory&utm_campaign=e06_no_login#tool) - Calculate wholesale-order contribution and target minimum quantities from production costs and fees. The calculator needs no account; saving cost recipes and scenarios requires an account and a paid plan after a trial.
 
 
 ### Communication


### PR DESCRIPTION
**https://perpiece.aifirm.app/#tool**

**Perpiece is a free wholesale-order calculator for small makers. It combines materials, labour, packaging, order quantity and percentage or fixed fees to show contribution after entered costs and a target minimum quantity. It belongs in Business and Finance because these calculations work immediately without registration. Saving cost recipes and scenarios is optional and requires an account, with a 14-day no-card trial followed by USD 19/month; the listing states that limitation.**

This is a maker submission for Perpiece and was prepared with AI assistance. The service is new, launched in September 2026. No independent customer results, audience size or endorsement are claimed. The link contains source/campaign attribution and goes directly to the free calculator.

Verified in the live browser on 11 September without signing in: the fictional 24-unit example shows USD 141.20 contribution with a USD 10 first-order fee, then USD 151.20 when that fee is set to zero. Reset restores USD 141.20. No account was created, and the captured browser console had no warnings or errors. The added HTTPS link responds successfully. No private application code is included in this contribution.

# By submitting this pull request I confirm I've read and complied with the below requirements.

- [x] I have read the [Contribution guidelines](https://github.com/aviaryan/awesome-no-login-web-apps/blob/master/CONTRIBUTING.md) and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title: `Add Perpiece wholesale-order calculator`.
- [x] The app I added is not a duplicate. I checked the current list and existing pull requests.
