### PR TITLE
Add IntelCue RSS Reader to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ To save the world from creating user accounts and installing software applicatio
 * [WeGoWhen](https://wegowhen.com) - Finds the dates a group can travel together: everyone taps the days they are free and it ranks the consecutive date ranges that fit the most people. Days only, so no time-of-day scheduling.
 * [Zero Dollar Domains](https://arynjennen1989-stack.github.io/) - Live RDAP hunter for unused cheap TLD names plus a catalog of still-free domain and subdomain programs. No signup. Not an expired-.com dump.
 * [BarcodeGen](https://www.barcodegen.net) - Free online barcode generator supporting 35+ formats including Code 128, EAN-13, QR Code, and Data Matrix with bulk generation and PNG/SVG download.
+* [IntelCue RSS Reader](https://www.intelcue.ai/tools/rss-reader) - Free RSS reader with no feed limit, OPML import/export, full-text search and a keyword watchlist; paste a site URL and it finds the feed. Subscriptions are stored in browser local storage only, so they do not sync across devices.
 
 
 ### Miscellaneous


### PR DESCRIPTION
Adds [IntelCue RSS Reader](https://www.intelcue.ai/tools/rss-reader) to **Utilities (uncategorized)**.

Why it fits this list:
- Works fully without login: you are reading within seconds of landing, no account, no email confirmation, no trial.
- Free with no feed limit, no ads or promoted items.
- OPML import/export, full-text search across loaded items, keyword watchlist with highlighting, keyboard navigation.
- Paste a site URL (not a feed URL) and it discovers the feed for you.

Shortcoming stated in the description, per the contributing guidelines: subscriptions live in browser local storage only, so they do not sync across devices.

Added at the bottom of the category, description ends with a full stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
