### PR TITLE
Add Smart Money 13F (SEC 13F quarterly holdings tracker) to Business and Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To save the world from creating user accounts and installing software applicatio
 * [InvoiceToMe](https://invoiceto.me/) - Generate professional invoices from various templates with your company details.
 * [ShiftDispatch Schedule Builder](https://shiftdispatchhq.com/schedule-builder) - Build weekly staff schedules, import or export spreadsheets, print schedules, and optionally publish a read-only link without creating an account.
 * [QuoteChime](https://quotechime.pages.dev/?ref=awesomenologin#generator) - Draft a finite quote follow-up sequence for service businesses in the browser. It does not send messages or store customer details.
+* [Smart Money 13F](https://13f.aiworkagent.org) - Track quarterly 13F-HR institutional holdings per fund manager — new buys, exits, and position changes, straight from SEC EDGAR.
 
 
 ### Communication


### PR DESCRIPTION
Adds one entry to **Business and Finance**.

13F filings tell you what the big funds bought last quarter, but on EDGAR they are raw text tables. [Smart Money 13F](https://13f.aiworkagent.org) turns each filing into a per-fund quarterly diff — new buys, exits, position changes — fed by an update script that reads EDGAR directly. The whole site works without an account.

I built and maintain the site. Separate note: PR #565 (a meme gallery, Graphics section) is also mine and still open — different project, kept separate on purpose.
